### PR TITLE
Execute after InstallFinalize

### DIFF
--- a/custom_action_with_condition/patch.xml
+++ b/custom_action_with_condition/patch.xml
@@ -5,8 +5,8 @@
 			FileKey="CM_FP_bin.hw.exe"/>
 		<InstallExecuteSequence>
 			<Custom Action="MyCustomAction"
-				After="InstallFiles">
-				Installed 
+				After="InstallFinalize">
+				NOT Installed 
 			</Custom>
 		</InstallExecuteSequence>
 	</CPackWiXFragment>


### PR DESCRIPTION
InstallFiles only **schedules** files to be installed, and occurs before the files actually exist on disk. Waiting until after InstallFinalize allows running installed files. Changing the condition to "NOT Installed" makes it execute if the installer starts without the program being installed, and then actually installs it. It does not execute during a "repair" / "reinstall" operation.